### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Next Identity Simple Login</title>
-    <!-- Uncomment this line to use the latest version of the SDK from jsdelivr -->
-    <!-- <script src="https://cdn.jsdelivr.net/gh/next-reason/ni-js-sdk@latest/next-identity-client.js"></script> -->
-    <!-- Or reference the js directly to have more control -->
-    <script src="next-identity-client.js"></script>
+    <!-- use the latest version of the SDK from jsdelivr -->
+   <script src="https://cdn.jsdelivr.net/gh/next-reason/ni-js-sdk@latest/next-identity-client.js"></script> 
+    <!-- Or uncomment this line to reference the js directly to have more control -->
+    <!-- <script src="next-identity-client.js"></script> -->
 </head>
 <body>
     <main>


### PR DESCRIPTION
defaulted so that we reference the js file from jsdeliver by default - as the docs say - rather than forcing someone to download and use the js file.

Essentially making it so that the sdk will work out of the box without someone uncommenting or adjusting code.